### PR TITLE
BUGFIX: Use queue className from options

### DIFF
--- a/bin/fast-rabbit
+++ b/bin/fast-rabbit
@@ -20,7 +20,12 @@ $queueSettings = $config['queueSettings'];
 $queueOptions = $queueSettings['options'];
 $command = $config['command'];
 
-$queue = new RabbitQueue($queueName, $queueOptions);
+$queueClassName = $queueSettings['className'] ?? RabbitQueue::class;
+if (!is_a($queueClassName, RabbitQueue::class, true)) {
+    throw new RuntimeException(sprintf('Queue "%s" must be a type of RabbitQueue!', $queueName), 1646058608);
+}
+
+$queue = new $queueClassName($queueName, $queueOptions);
 $messageCache = CacheFactory::get($config);
 $lock = new Lock($config['workerPool']['numberOfWorkers'], $config['workerPool']['lockFileDirectory']);
 


### PR DESCRIPTION
With https://github.com/t3n/JobQueue.RabbitMQ/pull/17 there may be different
implementations of the RabbitQueue. When using anything but the default one,
we have to respect the className given by the queueSettings.